### PR TITLE
Main: eliminate “No window with id …” races in lockPannel

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -5,6 +5,7 @@ import pbkdf2 from "./pbkdf2.js";
     let LOCKED = false;
     let PANNEL_OPENED = false;
     let PANNEL_ID = null;
+    let IS_CREATING_PANEL = false;
     let ALLOW_CHANGE = false;
 
     let config = null;
@@ -88,40 +89,55 @@ import pbkdf2 from "./pbkdf2.js";
         },
 
         lockPannel: async (fromIcon = false) => {
-            if (!LOCKED) return;
+            if (!LOCKED || IS_CREATING_PANEL) return;
 
-            await blocker.getConf();
+            try {
+                await blocker.getConf();
 
-            if (!PASSWD_SETED) {
-                if (fromIcon) {
-                    await chrome.windows.create({
-                        type: "popup",
-                        width: 640,
-                        height: 580,
-                        focused: true,
-                        url: "./html/options.html"
-                    });
+                if (!PASSWD_SETED) {
+                    if (fromIcon) {
+                        await chrome.windows.create({
+                            type: "popup",
+                            width: 640,
+                            height: 580,
+                            focused: true,
+                            url: "./html/options.html"
+                        });
+                    }
+                    return;
                 }
-                return;
+
+                if (!PANNEL_OPENED) {
+                    IS_CREATING_PANEL = true;
+                    const createdPannel = await chrome.windows.create({
+                        type: "popup",
+                        width: 520,
+                        height: 370,
+                        focused: true,
+                        url: PASSWD_SETED ? "./html/unlock.html" : "./html/options.html"
+                    });
+                    PANNEL_ID = createdPannel?.id ?? null;
+                    PANNEL_OPENED = !!PANNEL_ID;
+                    // tiny delay to let Chrome register the new window fully before enumerating/removing others
+                    await new Promise(r => setTimeout(r, 50));
+                }
+
+                const windows = await chrome.windows.getAll();
+                const toRemove = windows.filter(win => win?.id && win.id !== PANNEL_ID);
+                for (const win of toRemove) {
+                    try {
+                        // verify window still exists
+                        await chrome.windows.get(win.id);
+                        await chrome.windows.remove(win.id);
+                    } catch (_) {
+                        // ignore: already gone or race
+                    }
+                }
+            } catch (e) {
+                console.debug("lockPannel soft error (ignored):", e?.message || e);
+            } finally {
+                IS_CREATING_PANEL = false;
             }
-
-
-            const windows = await chrome.windows.getAll();
-
-            if (!PANNEL_OPENED) {
-                const createdPannel = await chrome.windows.create({
-                    type: "popup",
-                    width: 520,
-                    height: 370,
-                    focused: true,
-                    url: PASSWD_SETED ? "./html/unlock.html" : "./html/options.html"
-                });
-                PANNEL_ID = createdPannel?.id;
-                PANNEL_OPENED = true;
-            }
-            await Promise.all(
-                windows.map(win => win.id && win.id !== PANNEL_ID && chrome.windows.remove(win.id))
-            );
         },
 
         handle: async () => {


### PR DESCRIPTION
- What changed
  - Debounced panel creation using `IS_CREATING_PANEL` to prevent re-entrant calls while the panel is being created.
  - Reordered logic to create the panel first, then fetch `chrome.windows.getAll()` and close others.
  - Added a short 50ms delay after creating the panel so the new window is fully registered before enumeration/removal.
  - Replaced parallel `remove` calls with sequential, verified removal:
    - `chrome.windows.get(id)` to confirm existence
    - `chrome.windows.remove(id)` in a try/catch per window
  - Wrapped the entire [lockPannel()](cci:1://file:///c:/Proj/GitForks/blocker/lib/main.js:90:8-140:9) body in `try/catch/finally` to ensure we don’t surface unhandled promise rejections in DevTools; logs are downgraded to `console.debug`.

- Why
  - The “Uncaught (in promise) Error: No window with id …” was caused by races where a window was already closed by the time we attempted removal.
  - Sequential, verified closure and defensive guards remove the noise without changing UX.

- Scope
  - Only [lib/main.js](cci:7://file:///c:/Proj/GitForks/blocker/lib/main.js:0:0-0:0) changed, specifically [lockPannel()](cci:1://file:///c:/Proj/GitForks/blocker/lib/main.js:90:8-140:9); no behavior changes to other files.

- Testing
  1. Reload the extension.
  2. Trigger lock flow (action icon, startup).
  3. Confirm the panel opens and other windows close.
  4. Check Extensions console: no “No window with id …” errors should appear.

- Notes
  - If needed, we can further constrain which windows we close (e.g., `type === "normal"`) or snapshot IDs pre-creation as an extra safety measure.